### PR TITLE
Mci move around

### DIFF
--- a/nodes/taspar.json
+++ b/nodes/taspar.json
@@ -1,11 +1,9 @@
 {
   "run_list": [
-    "role[jenkins-master]",,
-    "recipe[s3fs]",
-    "recipe[publisher-mci]",
+    "role[jenkins-master]",
     "recipe[zabbix]"
   ],
   "automatic": {
-    "ipaddress": "taspar"
+    "ipaddress": "207.154.207.181"
   }
 }

--- a/nodes/taspar.json
+++ b/nodes/taspar.json
@@ -1,6 +1,7 @@
 {
   "run_list": [
     "role[jenkins-master]",
+    "recipe[mci-redirect]",
     "recipe[zabbix]"
   ],
   "automatic": {

--- a/nodes/thrift.json
+++ b/nodes/thrift.json
@@ -1,8 +1,0 @@
-{
-  "run_list": [
-    "role[server-common]"
-  ],
-  "automatic": {
-    "ipaddress": "thrift"
-  }
-}

--- a/nodes/torvald.json
+++ b/nodes/torvald.json
@@ -1,7 +1,8 @@
 {
   "run_list": [
     "role[server-common]",
-    "recipe[publisher-mci]"
+    "recipe[publisher-mci]",
+    "recipe[zabbix]"
   ],
   "automatic": {
     "ipaddress": "torvald"

--- a/nodes/torvald.json
+++ b/nodes/torvald.json
@@ -1,0 +1,9 @@
+{
+  "run_list": [
+    "role[server-common]",
+    "recipe[publisher-mci]"
+  ],
+  "automatic": {
+    "ipaddress": "torvald"
+  }
+}

--- a/site-cookbooks/mci-redirect/CHANGELOG.md
+++ b/site-cookbooks/mci-redirect/CHANGELOG.md
@@ -1,0 +1,11 @@
+# mci-redirect CHANGELOG
+
+This file is used to list changes made in each version of the mci-redirect cookbook.
+
+## 0.1.0
+- [your_name] - Initial release of mci-redirect
+
+- - -
+Check the [Markdown Syntax Guide](http://daringfireball.net/projects/markdown/syntax) for help with Markdown.
+
+The [Github Flavored Markdown page](http://github.github.com/github-flavored-markdown/) describes the differences between markdown on github and standard markdown.

--- a/site-cookbooks/mci-redirect/README.md
+++ b/site-cookbooks/mci-redirect/README.md
@@ -1,0 +1,80 @@
+# mci-redirect Cookbook
+
+TODO: Enter the cookbook description here.
+
+e.g.
+This cookbook makes your favorite breakfast sandwich.
+
+## Requirements
+
+TODO: List your cookbook requirements. Be sure to include any requirements this cookbook has on platforms, libraries, other cookbooks, packages, operating systems, etc.
+
+e.g.
+### Platforms
+
+- SandwichOS
+
+### Chef
+
+- Chef 12.0 or later
+
+### Cookbooks
+
+- `toaster` - mci-redirect needs toaster to brown your bagel.
+
+## Attributes
+
+TODO: List your cookbook attributes here.
+
+e.g.
+### mci-redirect::default
+
+<table>
+  <tr>
+    <th>Key</th>
+    <th>Type</th>
+    <th>Description</th>
+    <th>Default</th>
+  </tr>
+  <tr>
+    <td><tt>['mci-redirect']['bacon']</tt></td>
+    <td>Boolean</td>
+    <td>whether to include bacon</td>
+    <td><tt>true</tt></td>
+  </tr>
+</table>
+
+## Usage
+
+### mci-redirect::default
+
+TODO: Write usage instructions for each cookbook.
+
+e.g.
+Just include `mci-redirect` in your node's `run_list`:
+
+```json
+{
+  "name":"my_node",
+  "run_list": [
+    "recipe[mci-redirect]"
+  ]
+}
+```
+
+## Contributing
+
+TODO: (optional) If this is a public cookbook, detail the process for contributing. If this is a private cookbook, remove this section.
+
+e.g.
+1. Fork the repository on Github
+2. Create a named feature branch (like `add_component_x`)
+3. Write your change
+4. Write tests for your change (if applicable)
+5. Run the tests, ensuring they all pass
+6. Submit a Pull Request using Github
+
+## License and Authors
+
+Authors: TODO: List authors
+

--- a/site-cookbooks/mci-redirect/definitions/redirect.rb
+++ b/site-cookbooks/mci-redirect/definitions/redirect.rb
@@ -1,0 +1,48 @@
+#
+# Cookbook Name:: apache2
+# Definition:: web_app
+#
+# Copyright 2008-2013, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+define :redirect, :template => 'redirect.conf.erb', :local => false, :enable => true do
+  application_name = params[:name]
+
+  include_recipe 'apache2::default'
+  include_recipe 'apache2::mod_rewrite'
+  include_recipe 'apache2::mod_deflate'
+  include_recipe 'apache2::mod_headers'
+
+  template "#{node['apache']['dir']}/sites-available/#{application_name}.conf" do
+    source params[:template]
+    local params[:local]
+    owner 'root'
+    group node['apache']['root_group']
+    mode '0644'
+    cookbook params[:cookbook] if params[:cookbook]
+    variables(
+      :application_name => application_name,
+      :params           => params
+    )
+    if ::File.exist?("#{node['apache']['dir']}/sites-enabled/#{application_name}.conf")
+      notifies :reload, 'service[apache2]', :delayed
+    end
+  end
+
+  site_enabled = params[:enable]
+  apache_site params[:name] do
+    enable site_enabled
+  end
+end

--- a/site-cookbooks/mci-redirect/metadata.rb
+++ b/site-cookbooks/mci-redirect/metadata.rb
@@ -1,0 +1,9 @@
+name             'mci-redirect'
+maintainer       'YOUR_COMPANY_NAME'
+maintainer_email 'YOUR_EMAIL'
+license          'All rights reserved'
+description      'Installs/Configures mci-redirect'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          '0.1.0'
+
+depends 'apache2'

--- a/site-cookbooks/mci-redirect/recipes/default.rb
+++ b/site-cookbooks/mci-redirect/recipes/default.rb
@@ -1,0 +1,15 @@
+#
+# Cookbook Name:: mci-redirect
+# Recipe:: default
+#
+# Copyright 2016, YOUR_COMPANY_NAME
+#
+# All rights reserved - Do Not Redistribute
+#
+
+redirect 'mobile.neon.pangea.pub' do
+  server_name 'mobile.neon.pangea.pub'
+  new_server_name 'neon.plasma-mobile.org:8080'
+  server_port 80
+  docroot '/var/www/html'
+end

--- a/site-cookbooks/mci-redirect/templates/default/redirect.conf.erb
+++ b/site-cookbooks/mci-redirect/templates/default/redirect.conf.erb
@@ -1,0 +1,9 @@
+<VirtualHost *:<%= @params[:server_port] || Apache2::Listen.listen_ports_by_address(node).values.map(&:to_a).flatten.first %>>
+  ServerName <%= @params[:server_name] %>
+  <% if @params[:server_aliases] -%>
+  ServerAlias <%= @params[:server_aliases].join " " %>
+  <% end -%>
+  DocumentRoot <%= @params[:docroot] %>
+
+  RedirectMatch (.*)$ "http://<%= @params[:new_server_name] %>$1"
+</VirtualHost>

--- a/site-cookbooks/publisher-mci/recipes/default.rb
+++ b/site-cookbooks/publisher-mci/recipes/default.rb
@@ -7,6 +7,10 @@
 # All rights reserved - Do Not Redistribute
 #
 
+if node['apache']['listen'] == ['*:80']
+  node.default['apache']['listen'] = ['*:80', "*:8080"]
+end
+
 ## FIXME: codecopy
 include_recipe 'apt'
 
@@ -30,21 +34,37 @@ publisher_setup 'mci' do
   apiport 9090
 end
 
-# GPG
-include_recipe 'bsw_gpg::default'
-bsw_gpg_load_key_from_string 'a string key' do
-  key_contents KeyBag.load('mci.private.key')
-  for_user 'mci'
+directory "/home/mci/images" do
+  owner 'mci'
+  group 'mci'
+  mode '0755'
+  action :create
+  recursive true
 end
+
+# GPG
+# Doesn't work currently with gpg2, done manually for now
+# see: https://github.com/wied03/cookbook-gpg/issues/5
+#include_recipe 'bsw_gpg::default'
+#bsw_gpg_load_key_from_string 'a string key' do
+#  key_contents KeyBag.load('mci.private.key')
+#  for_user 'mci'
+#end
 
 # Apache
 web_app 'mci_web_repo' do
-  # server_name node['hostname']
-  # server_aliases [node['fqdn'], 'neon.pangea.pub']
-  server_name 'mobile.neon.pangea.pub'
-  server_aliases ['mobile.kci.pangea.pub', 'mobile.neon.pangea.pub']
-  server_port 80
+  server_name 'neon.plasma-mobile.org'
+  server_port 8080
   docroot '/home/mci/aptly/public/mci'
+  directory_options %w(Indexes FollowSymLinks)
+  allow_override 'All'
+  cookbook 'apache2'
+end
+
+web_app 'mci_images' do
+  server_name 'neon.plasma-mobile.org'
+  server_port 80
+  docroot '/home/mci/images'
   directory_options %w(Indexes FollowSymLinks)
   allow_override 'All'
   cookbook 'apache2'


### PR DESCRIPTION
Various changes

- Thrift is no more
- Torvald takes mci repo and mci images
- Taspar is 16.04 host now just with jenkins master.