### PR TITLE
make sure we have ruby-shadow for chef-workstation

### DIFF
--- a/site-cookbooks/jenkins-slave/recipes/default.rb
+++ b/site-cookbooks/jenkins-slave/recipes/default.rb
@@ -18,8 +18,6 @@ apt_repository 'ubuntu-updates' do
   only_if { node['kernel']['machine'].start_with?('arm') }
 end
 
-chef_gem 'shadow'
-
 user_account 'jenkins-slave' do
   ssh_keys [
     'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCiLBt3u8Ldo3/bwIYI3t4QZ8yW7lMdWLy92gOxk0er5Rb1baKvubFIfTRL18I4FCvYJyzchCGZhxFfCkO5FiKNhOlKWbPJRKgitj1y6t02Jlyw0Z+zQXKe1srpwwQa2iN1LuTINcRoun/+Ouq52uQeRaye9zV3ikT+53/GcsfJTgxkJN2IOpIaLdEA3epuqnStpXdGYvAjycUngbVJASHWXsZUCPtZK6acxoxHvFPdroEVs+rB3HdWFUoaFECRJ8LQo21p7qlFIeC03scUmYs2cDaBne8h0NhA9q/0o+HQqaf2zam8fJiMqKo3eTYUt6jRStzxT+tpg3zyDlKsipL/ jenkins@drax',

--- a/site-cookbooks/server-common/recipes/default.rb
+++ b/site-cookbooks/server-common/recipes/default.rb
@@ -72,3 +72,11 @@ apt_update 'update_for_tzdata'
 # - update-notifier-common contains handy motd extensions
 # - systemd-container contains machinectl which is much better than sudo
 apt_package %w[tzdata gnupg2 update-notifier-common systemd-container]
+
+# For some unknown reason chef 15.17.4 ships with ruby 2.6.7 that includes ruby-shadow
+# but chef-workstation 23.4.1032 ships ruby 3.1.2 but does not include ruby-shadow which
+# make it a complete shit show.  So chef_gem it in early.
+# See: https://github.com/chef/chef-workstation/issues/2141
+chef_gem 'ruby-shadow' do
+  action :install
+end


### PR DESCRIPTION
For some unknown reason chef 15.17.4 ships with ruby 2.6.7 that includes ruby-shadow but chef-workstation 23.4.1032 ships ruby 3.1.2 but does not include ruby-shadow which make it a complete shit show.  So chef_gem it in early. See: https://github.com/chef/chef-workstation/issues/2141