### PR TITLE
*_attribute_whitelist has become allowed_*_attributes 

### DIFF
--- a/.chef/knife.rb
+++ b/.chef/knife.rb
@@ -9,7 +9,7 @@ data_bag_path    "#{__dir__}/../data_bags"
 #   on BOOTSTRAP !!!. convering will not pass these values. To apply them to
 #   future converges you need to bootstrap the server again (possibly with
 #   --no-converge if no converge should happen).
-knife[:automatic_attribute_whitelist] = %w[
+knife[:allowed_automatic_attributes] = %w[
   fqdn
   os
   os_version
@@ -25,7 +25,7 @@ knife[:automatic_attribute_whitelist] = %w[
   chef_packages
   current_user
 ]
-knife[:default_attribute_whitelist] = []
+knife[:allowed_default_attributes] = []
 
 cookbook_license 'gplv3'
 cookbook_copyright ENV['DEBFULLNAME'] if ENV.include?('DEBFULLNAME')

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Requirements
 
-- Ruby 3.1.3 install with rbenv e.g. https://www.digitalocean.com/community/tutorials/how-to-install-ruby-on-rails-with-rbenv-on-ubuntu-22-04
+- Ruby 3.3.0 install with rbenv e.g. https://www.digitalocean.com/community/tutorials/how-to-install-ruby-on-rails-with-rbenv-on-ubuntu-22-04
 - SSH access to relevant hosts
 - For convenience a .ssh/config entry to make the hosts name accessible (e.g. map IP to hostname such as 'drax' or 'taspar')
 


### PR DESCRIPTION
attribute_whitelist/blacklist was depredcated in chef infra client 16.3 and EOL in 18.4.12